### PR TITLE
Replace ICellDescription inheritance with std::variant value type

### DIFF
--- a/src/SingleLayerOptics/src/BSDFLayerMaker.cpp
+++ b/src/SingleLayerOptics/src/BSDFLayerMaker.cpp
@@ -27,8 +27,7 @@ namespace SingleLayerOptics
       CBSDFLayerMaker::getSpecularLayer(const std::shared_ptr<CMaterial> & t_Material,
                                         const BSDFHemisphere & t_BSDF)
     {
-        auto aDescription = std::make_shared<CSpecularCellDescription>();
-        auto aCell = std::make_shared<CSpecularCell>(t_Material, aDescription);
+        auto aCell = std::make_shared<CSpecularCell>(t_Material, CSpecularCellDescription{});
         return std::make_shared<CSpecularBSDFLayer>(aCell, t_BSDF);
     }
 
@@ -36,8 +35,8 @@ namespace SingleLayerOptics
       CBSDFLayerMaker::getDirDifLayer(const std::shared_ptr<CMaterial> & t_Material,
                                       const BSDFHemisphere & t_BSDF)
     {
-        auto aDescription = std::make_shared<CSpecularCellDescription>();
-        auto aCell = std::make_shared<CMaterialDirectionalDiffuseCell>(t_Material, aDescription);
+        auto aCell =
+          std::make_shared<CMaterialDirectionalDiffuseCell>(t_Material, CSpecularCellDescription{});
         return std::make_shared<CMaterialDirectionalDiffuseBSDFLayer>(aCell, t_BSDF);
     }
 
@@ -46,8 +45,7 @@ namespace SingleLayerOptics
                                                     const BSDFHemisphere & t_BSDF,
                                                     PVPowerPropertiesTable powerTable)
     {
-        auto aDecription{std::make_shared<CSpecularCellDescription>()};
-        auto aCell = std::make_shared<CSpecularCell>(t_Material, aDecription);
+        auto aCell = std::make_shared<CSpecularCell>(t_Material, CSpecularCellDescription{});
         auto aLayer = std::make_shared<PhotovoltaicSpecularBSDFLayer>(aCell, t_BSDF);
         aLayer->assignPowerTable(std::move(powerTable));
 
@@ -62,10 +60,8 @@ namespace SingleLayerOptics
                                                   double thickness,
                                                   double radius)
     {
-        std::shared_ptr<ICellDescription> aCellDescription =
-          std::make_shared<CCircularCellDescription>(x, y, thickness, radius);
-        std::shared_ptr<CUniformDiffuseCell> aCell =
-          std::make_shared<CPerforatedCell>(t_Material, aCellDescription);
+        auto aCell = std::make_shared<CPerforatedCell>(
+          t_Material, CCircularCellDescription{x, y, thickness, radius});
         return std::make_shared<CUniformDiffuseBSDFLayer>(aCell, t_BSDF);
     }
 
@@ -78,10 +74,8 @@ namespace SingleLayerOptics
                                                      double xHole,
                                                      double yHole)
     {
-        std::shared_ptr<ICellDescription> aCellDescription =
-          std::make_shared<CRectangularCellDescription>(x, y, thickness, xHole, yHole);
-        std::shared_ptr<CUniformDiffuseCell> aCell =
-          std::make_shared<CPerforatedCell>(t_Material, aCellDescription);
+        auto aCell = std::make_shared<CPerforatedCell>(
+          t_Material, CRectangularCellDescription{x, y, thickness, xHole, yHole});
         return std::make_shared<CUniformDiffuseBSDFLayer>(aCell, t_BSDF);
     }
 
@@ -110,16 +104,15 @@ namespace SingleLayerOptics
                                         DistributionMethod method,
                                         bool isHorizontal)
     {
-        std::shared_ptr<ICellDescription> aCellDescription =
-          std::make_shared<CVenetianCellDescription>(geometry, numOfSlatSegments);
+        CVenetianCellDescription aCellDescription{geometry, numOfSlatSegments};
 
         const auto profileAnglesIncoming = t_BSDF.profileAngles(BSDFDirection::Incoming);
-        std::dynamic_pointer_cast<CVenetianCellDescription>(aCellDescription)
-          ->preCalculateForProfileAngles(FenestrationCommon::Side::Front, profileAnglesIncoming);
+        aCellDescription.preCalculateForProfileAngles(FenestrationCommon::Side::Front,
+                                                      profileAnglesIncoming);
 
         const auto profileAnglesOutgoing = t_BSDF.profileAngles(BSDFDirection::Outgoing);
-        std::dynamic_pointer_cast<CVenetianCellDescription>(aCellDescription)
-          ->preCalculateForProfileAngles(FenestrationCommon::Side::Back, profileAnglesOutgoing);
+        aCellDescription.preCalculateForProfileAngles(FenestrationCommon::Side::Back,
+                                                      profileAnglesOutgoing);
 
         static const auto horizontalVenetianRotation{0.0};
         static const auto verticalVenetianRotation{90.0};
@@ -143,8 +136,7 @@ namespace SingleLayerOptics
       CBSDFLayerMaker::getPerfectlyDiffuseLayer(const std::shared_ptr<CMaterial> & t_Material,
                                                 const BSDFHemisphere & t_BSDF)
     {
-        auto aDescription = std::make_shared<CFlatCellDescription>();
-        auto aCell = std::make_shared<CUniformDiffuseCell>(t_Material, aDescription);
+        auto aCell = std::make_shared<CUniformDiffuseCell>(t_Material, CFlatCellDescription{});
         return std::make_shared<CUniformDiffuseBSDFLayer>(aCell, t_BSDF);
     }
 
@@ -152,8 +144,7 @@ namespace SingleLayerOptics
       CBSDFLayerMaker::getHomogeneousDiffuseLayer(const std::shared_ptr<CMaterial> & t_Material,
                                                   const BSDFHemisphere & t_BSDF)
     {
-        auto aDescription = std::make_shared<CFlatCellDescription>();
-        auto aCell = std::make_shared<CHomogeneousDiffuseCell>(t_Material, aDescription);
+        auto aCell = std::make_shared<CHomogeneousDiffuseCell>(t_Material, CFlatCellDescription{});
         return std::make_shared<CHomogeneousDiffuseBSDFLayer>(aCell, t_BSDF);
     }
 
@@ -161,8 +152,7 @@ namespace SingleLayerOptics
       CBSDFLayerMaker::getDirectionalDiffuseLayer(const std::shared_ptr<CMaterial> & t_Material,
                                                   const BSDFHemisphere & t_BSDF)
     {
-        auto aDescription = std::make_shared<CFlatCellDescription>();
-        auto aCell = std::make_shared<CDirectionalDiffuseCell>(t_Material, aDescription);
+        auto aCell = std::make_shared<CDirectionalDiffuseCell>(t_Material, CFlatCellDescription{});
         return std::make_shared<CDirectionalDiffuseBSDFLayer>(aCell, t_BSDF);
     }
 
@@ -170,8 +160,7 @@ namespace SingleLayerOptics
       CBSDFLayerMaker::getPreLoadedBSDFLayer(const std::shared_ptr<CMaterial> & t_Material,
                                              const BSDFHemisphere & t_BSDF)
     {
-        auto aDescription = std::make_shared<CFlatCellDescription>();
-        auto aCell = std::make_shared<CDirectionalDiffuseCell>(t_Material, aDescription);
+        auto aCell = std::make_shared<CDirectionalDiffuseCell>(t_Material, CFlatCellDescription{});
         return std::make_shared<CMatrixBSDFLayer>(aCell, t_BSDF);
     }
 
@@ -181,15 +170,15 @@ namespace SingleLayerOptics
                                      double diameter,
                                      double spacing)
     {
-        auto aDescription = std::make_shared<CWovenCellDescription>(diameter, spacing);
-        auto aCell = std::make_shared<CWovenCell>(t_Material, aDescription);
+        auto aCell =
+          std::make_shared<CWovenCell>(t_Material, CWovenCellDescription{diameter, spacing});
         return std::make_shared<CUniformDiffuseBSDFLayer>(aCell, t_BSDF);
     }
 
     CBSDFLayerMaker::CBSDFLayerMaker(const std::shared_ptr<CMaterial> & t_Material,
                                      const BSDFHemisphere & t_BSDF,
-                                     std::shared_ptr<ICellDescription> t_Description,
-                                     const DistributionMethod t_Method) :
+                                     std::optional<CellDescription> t_Description,
+                                     DistributionMethod t_Method) :
         m_Cell(nullptr)
     {
         if(t_Material == nullptr)
@@ -197,70 +186,51 @@ namespace SingleLayerOptics
             throw std::runtime_error("Material for BSDF layer must be defined.");
         }
 
-        // Specular BSDF layer is considered to be default. Default is used if t_Description is null
-        // pointer
-        if(t_Description == nullptr)
-        {
-            t_Description = std::make_shared<CSpecularCellDescription>();
-        }
+        // Specular BSDF layer is considered to be default. Default is used if no description is
+        // provided.
+        const CellDescription & description =
+          t_Description.value_or(CellDescription{CSpecularCellDescription{}});
 
-        // Specular cell
-        if(std::dynamic_pointer_cast<CSpecularCellDescription>(t_Description) != nullptr)
+        if(std::holds_alternative<CSpecularCellDescription>(description))
         {
             m_Layer = getSpecularLayer(t_Material, t_BSDF);
         }
-
-        if(std::dynamic_pointer_cast<CFlatCellDescription>(t_Description) != nullptr)
+        else if(std::holds_alternative<CFlatCellDescription>(description))
         {
             m_Layer = getPerfectlyDiffuseLayer(t_Material, t_BSDF);
         }
-
-        // Venetian cell
-        if(std::dynamic_pointer_cast<CVenetianCellDescription>(t_Description) != nullptr)
+        else if(const auto * venetian = std::get_if<CVenetianCellDescription>(&description))
         {
-            const auto description{
-              std::dynamic_pointer_cast<CVenetianCellDescription>(t_Description)};
             m_Layer = getVenetianLayer(t_Material,
                                        t_BSDF,
-                                       description->getVenetianGeometry(),
-                                       description->numberOfSegments(),
+                                       venetian->getVenetianGeometry(),
+                                       venetian->numberOfSegments(),
                                        t_Method,
                                        0);
         }
-
-        // Perforated cell
-        if(std::dynamic_pointer_cast<CCircularCellDescription>(t_Description) != nullptr)
+        else if(const auto * circular = std::get_if<CCircularCellDescription>(&description))
         {
-            const auto description{
-              std::dynamic_pointer_cast<CCircularCellDescription>(t_Description)};
             m_Layer = getCircularPerforatedLayer(t_Material,
                                                  t_BSDF,
-                                                 description->xDimension(),
-                                                 description->yDimension(),
-                                                 description->thickness(),
-                                                 description->radius());
+                                                 circular->xDimension(),
+                                                 circular->yDimension(),
+                                                 circular->thickness(),
+                                                 circular->radius());
         }
-
-        if(std::dynamic_pointer_cast<CRectangularCellDescription>(t_Description) != nullptr)
+        else if(const auto * rectangular = std::get_if<CRectangularCellDescription>(&description))
         {
-            const auto description{
-              std::dynamic_pointer_cast<CRectangularCellDescription>(t_Description)};
             m_Layer = getRectangularPerforatedLayer(t_Material,
                                                     t_BSDF,
-                                                    description->xDimension(),
-                                                    description->yDimension(),
-                                                    description->thickness(),
-                                                    description->xHole(),
-                                                    description->yHole());
+                                                    rectangular->xDimension(),
+                                                    rectangular->yDimension(),
+                                                    rectangular->thickness(),
+                                                    rectangular->xHole(),
+                                                    rectangular->yHole());
         }
-
-        // Woven cell
-        if(std::dynamic_pointer_cast<CWovenCellDescription>(t_Description) != nullptr)
+        else if(const auto * woven = std::get_if<CWovenCellDescription>(&description))
         {
             // Woven shades do not work with directional diffuse algorithm
-            const auto description{std::dynamic_pointer_cast<CWovenCellDescription>(t_Description)};
-            m_Layer =
-              getWovenLayer(t_Material, t_BSDF, description->diameter(), description->spacing());
+            m_Layer = getWovenLayer(t_Material, t_BSDF, woven->diameter(), woven->spacing());
         }
     }
 

--- a/src/SingleLayerOptics/src/BSDFLayerMaker.hpp
+++ b/src/SingleLayerOptics/src/BSDFLayerMaker.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include "PhotovoltaicProperties.hpp"
+#include "CellDescription.hpp"
 
 namespace FenestrationCommon::Venetian
 {
@@ -17,7 +19,6 @@ namespace SingleLayerOptics
         DirectionalDiffuse
     };
 
-    class ICellDescription;
     class CMaterial;
     class BSDFHemisphere;
     class CBSDFLayer;
@@ -100,8 +101,8 @@ namespace SingleLayerOptics
 
         CBSDFLayerMaker(const std::shared_ptr<CMaterial> & t_Material,
                         const BSDFHemisphere & t_BSDF,
-                        std::shared_ptr<ICellDescription> t_Description = nullptr,
-                        const DistributionMethod t_Method = DistributionMethod::UniformDiffuse);
+                        std::optional<CellDescription> t_Description = std::nullopt,
+                        DistributionMethod t_Method = DistributionMethod::UniformDiffuse);
 
         [[nodiscard]] std::shared_ptr<CBSDFLayer> getLayer() const;
         [[nodiscard]] std::shared_ptr<CBaseCell> getCell() const;

--- a/src/SingleLayerOptics/src/BaseCell.cpp
+++ b/src/SingleLayerOptics/src/BaseCell.cpp
@@ -11,11 +11,11 @@ using FenestrationCommon::CSeries;
 
 namespace SingleLayerOptics
 {
-    CBaseCell::CBaseCell() : m_Material(nullptr), m_CellDescription(nullptr), m_CellRotation(0)
+    CBaseCell::CBaseCell() : m_Material(nullptr), m_CellRotation(0)
     {}
 
     CBaseCell::CBaseCell(const std::shared_ptr<CMaterial> & t_Material,
-                         const std::shared_ptr<ICellDescription> & t_CellDescription,
+                         const CellDescription & t_CellDescription,
                          const double rotation) :
         m_Material(t_Material), m_CellDescription(t_CellDescription), m_CellRotation(rotation)
     {}
@@ -29,9 +29,10 @@ namespace SingleLayerOptics
     {
         if(m_CellRotation != 0)
         {
-            return m_CellDescription->Beam_dir_dir(t_Side, t_Direction.rotate(m_CellRotation));
+            return Beam_dir_dir(
+              m_CellDescription, t_Side, t_Direction.rotate(m_CellRotation));
         }
-        return m_CellDescription->Beam_dir_dir(t_Side, t_Direction);
+        return Beam_dir_dir(m_CellDescription, t_Side, t_Direction);
     }
 
     double CBaseCell::R_dir_dir(const Side, const CBeamDirection &)

--- a/src/SingleLayerOptics/src/BaseCell.hpp
+++ b/src/SingleLayerOptics/src/BaseCell.hpp
@@ -3,6 +3,8 @@
 #include <memory>
 #include <vector>
 
+#include "CellDescription.hpp"
+
 namespace FenestrationCommon
 {
     enum class Side;
@@ -13,7 +15,6 @@ namespace FenestrationCommon
 namespace SingleLayerOptics
 {
     class CMaterial;
-    class ICellDescription;
     class CBeamDirection;
 
     // Handles optical layer "cell". Base behavior is to calculate specular (direct-direct)
@@ -24,7 +25,7 @@ namespace SingleLayerOptics
         virtual ~CBaseCell() = default;
         CBaseCell();
         CBaseCell(const std::shared_ptr<CMaterial> & t_Material,
-                  const std::shared_ptr<ICellDescription> & t_CellDescription,
+                  const CellDescription & t_CellDescription,
                   double rotation = 0);
 
         virtual void setSourceData(const FenestrationCommon::CSeries & t_SourceData);
@@ -66,7 +67,7 @@ namespace SingleLayerOptics
 
     protected:
         std::shared_ptr<CMaterial> m_Material;
-        std::shared_ptr<ICellDescription> m_CellDescription;
+        CellDescription m_CellDescription;
 
         // This indicates cell rotation in phi angle
         double m_CellRotation;

--- a/src/SingleLayerOptics/src/CellDescription.cpp
+++ b/src/SingleLayerOptics/src/CellDescription.cpp
@@ -1,0 +1,13 @@
+#include "CellDescription.hpp"
+#include "BeamDirection.hpp"
+
+namespace SingleLayerOptics
+{
+    double Beam_dir_dir(CellDescription & description,
+                        const FenestrationCommon::Side t_Side,
+                        const CBeamDirection & t_Direction)
+    {
+        return std::visit([&](auto & cell) { return cell.Beam_dir_dir(t_Side, t_Direction); },
+                          description);
+    }
+}   // namespace SingleLayerOptics

--- a/src/SingleLayerOptics/src/CellDescription.hpp
+++ b/src/SingleLayerOptics/src/CellDescription.hpp
@@ -1,5 +1,13 @@
 #pragma once
 
+#include <variant>
+
+#include "SpecularCellDescription.hpp"
+#include "FlatCellDescription.hpp"
+#include "VenetianCellDescription.hpp"
+#include "PerforatedCellDescription.hpp"
+#include "WovenCellDescription.hpp"
+
 namespace FenestrationCommon
 {
     enum class Side;
@@ -9,18 +17,19 @@ namespace SingleLayerOptics
 {
     class CBeamDirection;
 
-    // Interface for describing a single optical cell within a window layer.
-    // Multiple cells are combined to form the complete window layer.
-    // Each cell must provide methods to calculate direct-to-direct transmittance and reflectance
-    // for a specified incoming direction and side. These calculations are essential for determining
-    // the overall optical properties of the window system.
-    class ICellDescription
-    {
-    public:
-        virtual ~ICellDescription() = default;
-        ICellDescription() = default;
+    // A cell description is one of a closed set of geometries. Previously these were subclasses of
+    // an ICellDescription interface held through a shared_ptr; they are now value types collected in
+    // a variant so cells can store the description directly (no inheritance, no heap allocation).
+    using CellDescription = std::variant<CSpecularCellDescription,
+                                         CFlatCellDescription,
+                                         CVenetianCellDescription,
+                                         CCircularCellDescription,
+                                         CRectangularCellDescription,
+                                         CWovenCellDescription>;
 
-        virtual double Beam_dir_dir(const FenestrationCommon::Side t_Side,
-                                    const CBeamDirection & t_Direction) = 0;
-    };
+    // Direct-to-direct beam fraction through the cell geometry. Dispatches over the active
+    // alternative, replacing the former ICellDescription::Beam_dir_dir virtual call.
+    double Beam_dir_dir(CellDescription & description,
+                        FenestrationCommon::Side t_Side,
+                        const CBeamDirection & t_Direction);
 }   // namespace SingleLayerOptics

--- a/src/SingleLayerOptics/src/DirectionalDiffuseCell.cpp
+++ b/src/SingleLayerOptics/src/DirectionalDiffuseCell.cpp
@@ -5,7 +5,7 @@ namespace SingleLayerOptics
 {
     CDirectionalDiffuseCell::CDirectionalDiffuseCell(
       const std::shared_ptr<CMaterial> & t_MaterialProperties,
-      const std::shared_ptr<ICellDescription> & t_Cell,
+      const CellDescription & t_Cell,
       double rotation) :
         CBaseCell(t_MaterialProperties, t_Cell, rotation)
     {}

--- a/src/SingleLayerOptics/src/DirectionalDiffuseCell.hpp
+++ b/src/SingleLayerOptics/src/DirectionalDiffuseCell.hpp
@@ -12,7 +12,6 @@ namespace FenestrationCommon
 
 namespace SingleLayerOptics
 {
-    class ICellDescription;
     class CBeamDirection;
     class CMaterial;
 
@@ -20,7 +19,7 @@ namespace SingleLayerOptics
     {
     public:
         CDirectionalDiffuseCell(const std::shared_ptr<CMaterial> & t_MaterialProperties,
-                                const std::shared_ptr<ICellDescription> & t_Cell,
+                                const CellDescription & t_Cell,
                                 double rotation = 0);
 
         // dir_dif and dir_dif_band functions are calculating portion of incoming beam that bounced

--- a/src/SingleLayerOptics/src/FlatCellDescription.hpp
+++ b/src/SingleLayerOptics/src/FlatCellDescription.hpp
@@ -1,19 +1,22 @@
 #pragma once
 
-#include "CellDescription.hpp"
+namespace FenestrationCommon
+{
+    enum class Side;
+}
 
 namespace SingleLayerOptics
 {
+    class CBeamDirection;
+
     // Cell description that needs to be used for perfect diffusers. Specular components are
     // set to zero
-    class CFlatCellDescription : public ICellDescription
+    class CFlatCellDescription
     {
     public:
-        ~CFlatCellDescription() override = default;
         CFlatCellDescription() = default;
 
-        double Beam_dir_dir(const FenestrationCommon::Side t_Side,
-                            const CBeamDirection & t_Direction) override;
+        double Beam_dir_dir(FenestrationCommon::Side t_Side, const CBeamDirection & t_Direction);
     };
 
 }   // namespace SingleLayerOptics

--- a/src/SingleLayerOptics/src/HomogeneousDiffuseCell.cpp
+++ b/src/SingleLayerOptics/src/HomogeneousDiffuseCell.cpp
@@ -10,7 +10,7 @@ namespace SingleLayerOptics
 {
     CHomogeneousDiffuseCell::CHomogeneousDiffuseCell(
       const std::shared_ptr<CMaterial> & t_MaterialProperties,
-      const std::shared_ptr<ICellDescription> & t_Cell,
+      const CellDescription & t_Cell,
       double rotation) :
         CBaseCell(t_MaterialProperties, t_Cell, rotation),
         CDirectionalDiffuseCell(t_MaterialProperties, t_Cell, rotation)

--- a/src/SingleLayerOptics/src/HomogeneousDiffuseCell.hpp
+++ b/src/SingleLayerOptics/src/HomogeneousDiffuseCell.hpp
@@ -13,7 +13,6 @@ namespace FenestrationCommon
 
 namespace SingleLayerOptics
 {
-    class ICellDescription;
     class CBeamDirection;
     class CMaterial;
 
@@ -21,7 +20,7 @@ namespace SingleLayerOptics
     {
     public:
         CHomogeneousDiffuseCell(const std::shared_ptr<CMaterial> & t_MaterialProperties,
-                                const std::shared_ptr<ICellDescription> & t_Cell,
+                                const CellDescription & t_Cell,
                                 double rotation = 0);
 
         // dir_dif and dir_dif_band functions are calculating portion of incoming beam that bounced

--- a/src/SingleLayerOptics/src/MaterialDirDifCell.cpp
+++ b/src/SingleLayerOptics/src/MaterialDirDifCell.cpp
@@ -9,7 +9,7 @@ namespace SingleLayerOptics
 
     CMaterialDirectionalDiffuseCell::CMaterialDirectionalDiffuseCell(
       const std::shared_ptr<CMaterial> & t_MaterialProperties,
-      const std::shared_ptr<ICellDescription> & t_Cell) :
+      const CellDescription & t_Cell) :
         CBaseCell(t_MaterialProperties, t_Cell, 0),
         CDirectionalDiffuseCell(t_MaterialProperties, t_Cell, 0)
     {}

--- a/src/SingleLayerOptics/src/MaterialDirDifCell.hpp
+++ b/src/SingleLayerOptics/src/MaterialDirDifCell.hpp
@@ -13,7 +13,6 @@ namespace FenestrationCommon
 
 namespace SingleLayerOptics
 {
-    class ICellDescription;
     class CBeamDirection;
     class CMaterial;
 
@@ -21,7 +20,7 @@ namespace SingleLayerOptics
     {
     public:
         CMaterialDirectionalDiffuseCell(const std::shared_ptr<CMaterial> & t_MaterialProperties,
-                                        const std::shared_ptr<ICellDescription> & t_Cell);
+                                        const CellDescription & t_Cell);
 
         double T_dir_dir(FenestrationCommon::Side t_Side,
                          const CBeamDirection & t_Direction) override;

--- a/src/SingleLayerOptics/src/PerforatedCell.cpp
+++ b/src/SingleLayerOptics/src/PerforatedCell.cpp
@@ -11,7 +11,7 @@ namespace SingleLayerOptics
     //  CPerforatedCell
     ////////////////////////////////////////////////////////////////////////////////////////////
     CPerforatedCell::CPerforatedCell(const std::shared_ptr<CMaterial> & t_MaterialProperties,
-                                     const std::shared_ptr<ICellDescription> & t_Cell) :
+                                     const CellDescription & t_Cell) :
         CBaseCell(t_MaterialProperties, t_Cell), CUniformDiffuseCell(t_MaterialProperties, t_Cell)
     {}
 }   // namespace SingleLayerOptics

--- a/src/SingleLayerOptics/src/PerforatedCell.hpp
+++ b/src/SingleLayerOptics/src/PerforatedCell.hpp
@@ -12,13 +12,11 @@ namespace FenestrationCommon
 
 namespace SingleLayerOptics
 {
-    class ICellDescription;
-
     class CPerforatedCell : public CUniformDiffuseCell
     {
     public:
         CPerforatedCell(const std::shared_ptr<CMaterial> & t_MaterialProperties,
-                        const std::shared_ptr<ICellDescription> & t_Cell);
+                        const CellDescription & t_Cell);
     };
 }   // namespace SingleLayerOptics
 

--- a/src/SingleLayerOptics/src/PerforatedCellDescription.cpp
+++ b/src/SingleLayerOptics/src/PerforatedCellDescription.cpp
@@ -7,16 +7,6 @@ using namespace FenestrationCommon;
 namespace SingleLayerOptics
 {
     //////////////////////////////////////////////////////////////////////////////////////////////////
-    // CPerforatedCellDescription
-    //////////////////////////////////////////////////////////////////////////////////////////////////
-
-    CPerforatedCellDescription::CPerforatedCellDescription(const double t_x,
-                                                           const double t_y,
-                                                           const double t_Thickness) :
-        m_x(t_x), m_y(t_y), m_Thickness(t_Thickness)
-    {}
-
-    //////////////////////////////////////////////////////////////////////////////////////////////////
     // CCircularCellDescription
     //////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -24,7 +14,6 @@ namespace SingleLayerOptics
                                                        const double t_y,
                                                        const double t_Thickness,
                                                        const double t_Radius) :
-        CPerforatedCellDescription(t_x, t_y, t_Thickness),
         m_x(t_x),
         m_y(t_y),
         m_Thickness(t_Thickness),
@@ -98,7 +87,6 @@ namespace SingleLayerOptics
                                                              const double t_Thickness,
                                                              const double t_XHole,
                                                              const double t_YHole) :
-        CPerforatedCellDescription(t_x, t_y, t_Thickness),
         m_x(t_x),
         m_y(t_y),
         m_Thickness(t_Thickness),

--- a/src/SingleLayerOptics/src/PerforatedCellDescription.hpp
+++ b/src/SingleLayerOptics/src/PerforatedCellDescription.hpp
@@ -1,32 +1,21 @@
 #ifndef PERFORATEDCELLDESCRIPTION_H
 #define PERFORATEDCELLDESCRIPTION_H
 
-#include "CellDescription.hpp"
+namespace FenestrationCommon
+{
+    enum class Side;
+}
 
 namespace SingleLayerOptics
 {
-    class CPerforatedCellDescription : public ICellDescription
+    class CBeamDirection;
+
+    class CCircularCellDescription
     {
     public:
-        CPerforatedCellDescription(const double t_x, const double t_y, const double t_Thickness);
+        CCircularCellDescription(double t_x, double t_y, double t_Thickness, double t_Radius);
 
-    protected:
-        double m_x;
-        double m_y;
-        double m_Thickness;
-    };
-
-    class CCircularCellDescription : public CPerforatedCellDescription
-    {
-    public:
-        virtual ~CCircularCellDescription() = default;
-        CCircularCellDescription(const double t_x,
-                                 const double t_y,
-                                 const double t_Thickness,
-                                 const double t_Radius);
-
-        double Beam_dir_dir(const FenestrationCommon::Side t_Side,
-                            const CBeamDirection & t_Direction);
+        double Beam_dir_dir(FenestrationCommon::Side t_Side, const CBeamDirection & t_Direction);
 
         [[nodiscard]] double xDimension() const;
         [[nodiscard]] double yDimension() const;
@@ -42,18 +31,13 @@ namespace SingleLayerOptics
         double m_Radius;
     };
 
-    class CRectangularCellDescription : public CPerforatedCellDescription
+    class CRectangularCellDescription
     {
     public:
-        virtual ~CRectangularCellDescription() = default;
-        CRectangularCellDescription(const double t_x,
-                                    const double t_y,
-                                    const double t_Thickness,
-                                    const double t_XHole,
-                                    const double t_YHole);
+        CRectangularCellDescription(
+          double t_x, double t_y, double t_Thickness, double t_XHole, double t_YHole);
 
-        double Beam_dir_dir(const FenestrationCommon::Side t_Side,
-                            const CBeamDirection & t_Direction);
+        double Beam_dir_dir(FenestrationCommon::Side t_Side, const CBeamDirection & t_Direction);
 
         [[nodiscard]] double xDimension() const;
         [[nodiscard]] double yDimension() const;

--- a/src/SingleLayerOptics/src/ScatteringLayer.cpp
+++ b/src/SingleLayerOptics/src/ScatteringLayer.cpp
@@ -64,7 +64,7 @@ namespace SingleLayerOptics
     {}
 
     CScatteringLayer::CScatteringLayer(const std::shared_ptr<CMaterial> & t_Material,
-                                       std::shared_ptr<ICellDescription> t_Description,
+                                       std::optional<CellDescription> t_Description,
                                        const DistributionMethod t_Method) :
         m_BSDFLayer(nullptr), m_Theta(0), m_Phi(0)
     {
@@ -72,7 +72,7 @@ namespace SingleLayerOptics
         // integration will be performed using BSDF distribution while direct-direct component will
         // be taken directly from cell.
         const auto aBSDF = BSDFHemisphere::create(BSDFBasis::Full);
-        auto aMaker = CBSDFLayerMaker(t_Material, aBSDF, t_Description, t_Method);
+        auto aMaker = CBSDFLayerMaker(t_Material, aBSDF, std::move(t_Description), t_Method);
         m_BSDFLayer = aMaker.getLayer();
     }
 

--- a/src/SingleLayerOptics/src/ScatteringLayer.hpp
+++ b/src/SingleLayerOptics/src/ScatteringLayer.hpp
@@ -15,7 +15,6 @@ namespace SingleLayerOptics
     class CLayerSingleComponent;
     class CMaterial;
     class CBSDFLayer;
-    class ICellDescription;
 
     enum class EmissivityPolynomials
     {
@@ -49,7 +48,7 @@ namespace SingleLayerOptics
                          double Rb_dif_dif);
 
         explicit CScatteringLayer(const std::shared_ptr<CMaterial> & t_Material,
-                                  std::shared_ptr<ICellDescription> t_Description = nullptr,
+                                  std::optional<CellDescription> t_Description = std::nullopt,
                                   DistributionMethod t_Method = DistributionMethod::UniformDiffuse);
 
         static CScatteringLayer createSpecularLayer(const std::shared_ptr<CMaterial> & t_Material);

--- a/src/SingleLayerOptics/src/SpecularCell.cpp
+++ b/src/SingleLayerOptics/src/SpecularCell.cpp
@@ -12,12 +12,12 @@ using namespace SpectralAveraging;
 namespace SingleLayerOptics
 {
     CSpecularCell::CSpecularCell(const std::shared_ptr<CMaterial> & t_MaterialProperties,
-                                 const std::shared_ptr<ICellDescription> & t_Cell) :
+                                 const CellDescription & t_Cell) :
         CBaseCell(t_MaterialProperties, t_Cell)
     {}
 
     CSpecularCell::CSpecularCell(const std::shared_ptr<CMaterial> & t_MaterialProperties) :
-        CBaseCell(t_MaterialProperties, std::make_shared<CSpecularCellDescription>())
+        CBaseCell(t_MaterialProperties, CSpecularCellDescription{})
     {}
 
     double CSpecularCell::T_dir_dir(const Side t_Side, const CBeamDirection & t_Direction)
@@ -53,19 +53,6 @@ namespace SingleLayerOptics
                                                       const CBeamDirection & t_Direction)
     {
         return m_Material->getBandProperties(Property::R, t_Side, t_Direction, t_Direction);
-    }
-
-    std::shared_ptr<CSpecularCellDescription> CSpecularCell::getCellAsSpecular() const
-    {
-        if(std::dynamic_pointer_cast<CSpecularCellDescription>(m_CellDescription) == nullptr)
-        {
-            assert("Incorrectly assigned cell description.");
-        }
-
-        std::shared_ptr<CSpecularCellDescription> aCell =
-          std::dynamic_pointer_cast<CSpecularCellDescription>(m_CellDescription);
-
-        return aCell;
     }
 
     double CSpecularCell::R_dir_dir_at_wavelength(Side t_Side,

--- a/src/SingleLayerOptics/src/SpecularCell.hpp
+++ b/src/SingleLayerOptics/src/SpecularCell.hpp
@@ -12,8 +12,6 @@ namespace FenestrationCommon
 
 namespace SingleLayerOptics
 {
-    class CSpecularCellDescription;
-    class ICellDescription;
     class CBeamDirection;
 
     // Calculates spectral properties of specular layer over the given wavelength range and it also
@@ -22,7 +20,7 @@ namespace SingleLayerOptics
     {
     public:
         CSpecularCell(const std::shared_ptr<CMaterial> & t_MaterialProperties,
-                      const std::shared_ptr<ICellDescription> & t_Cell);
+                      const CellDescription & t_Cell);
 
         explicit CSpecularCell(const std::shared_ptr<CMaterial> & t_MaterialProperties);
 
@@ -49,9 +47,6 @@ namespace SingleLayerOptics
         double R_dir_dir_at_wavelength(FenestrationCommon::Side t_Side,
                                        const CBeamDirection & t_Direction,
                                        size_t wavelengthIndex) override;
-
-    protected:
-        [[nodiscard]] std::shared_ptr<CSpecularCellDescription> getCellAsSpecular() const;
     };
 
 }   // namespace SingleLayerOptics

--- a/src/SingleLayerOptics/src/SpecularCellDescription.cpp
+++ b/src/SingleLayerOptics/src/SpecularCellDescription.cpp
@@ -5,9 +5,6 @@ using namespace FenestrationCommon;
 
 namespace SingleLayerOptics
 {
-    CSpecularCellDescription::CSpecularCellDescription()
-    {}
-
     double CSpecularCellDescription::Beam_dir_dir(const Side, const CBeamDirection &)
     {
         return 0;

--- a/src/SingleLayerOptics/src/SpecularCellDescription.hpp
+++ b/src/SingleLayerOptics/src/SpecularCellDescription.hpp
@@ -1,8 +1,6 @@
 #ifndef SPECULARCELLDESCRIPTION_H
 #define SPECULARCELLDESCRIPTION_H
 
-#include "CellDescription.hpp"
-
 namespace FenestrationCommon
 {
     enum class Side;
@@ -12,15 +10,15 @@ namespace FenestrationCommon
 
 namespace SingleLayerOptics
 {
-    class CSpecularCellDescription : public ICellDescription
+    class CBeamDirection;
+
+    class CSpecularCellDescription
     {
     public:
-        virtual ~CSpecularCellDescription() = default;
-        CSpecularCellDescription();
+        CSpecularCellDescription() = default;
 
-        double Beam_dir_dir(const FenestrationCommon::Side t_Side,
-                            const CBeamDirection & t_Direction) override;
-        double Rspecular(const FenestrationCommon::Side t_Side, const CBeamDirection & t_Direction);
+        double Beam_dir_dir(FenestrationCommon::Side t_Side, const CBeamDirection & t_Direction);
+        double Rspecular(FenestrationCommon::Side t_Side, const CBeamDirection & t_Direction);
     };
 
 }   // namespace SingleLayerOptics

--- a/src/SingleLayerOptics/src/UniformDiffuseCell.cpp
+++ b/src/SingleLayerOptics/src/UniformDiffuseCell.cpp
@@ -10,7 +10,7 @@ namespace SingleLayerOptics
 {
     CUniformDiffuseCell::CUniformDiffuseCell(
       const std::shared_ptr<CMaterial> & t_MaterialProperties,
-      const std::shared_ptr<ICellDescription> & t_Cell,
+      const CellDescription & t_Cell,
       double rotation) :
         CBaseCell(t_MaterialProperties, t_Cell, rotation)
     {}

--- a/src/SingleLayerOptics/src/UniformDiffuseCell.hpp
+++ b/src/SingleLayerOptics/src/UniformDiffuseCell.hpp
@@ -15,7 +15,6 @@ namespace FenestrationCommon
 
 namespace SingleLayerOptics
 {
-    class ICellDescription;
     class CBeamDirection;
     class CMaterial;
 
@@ -24,7 +23,7 @@ namespace SingleLayerOptics
     {
     public:
         CUniformDiffuseCell(const std::shared_ptr<CMaterial> & t_MaterialProperties,
-                            const std::shared_ptr<ICellDescription> & t_Cell,
+                            const CellDescription & t_Cell,
                             double rotation = 0);
 
         // dir_dif and dir_dif_band functions are calculating portion of incoming beam that bounced

--- a/src/SingleLayerOptics/src/VenetianCell.cpp
+++ b/src/SingleLayerOptics/src/VenetianCell.cpp
@@ -14,23 +14,17 @@ namespace SingleLayerOptics
     ////////////////////////////////////////////////////////////////////////////////////////////
 
     CVenetianBase::CVenetianBase(const std::shared_ptr<CMaterial> & t_MaterialProperties,
-                                 const std::shared_ptr<ICellDescription> & t_Cell,
+                                 const CellDescription & t_Cell,
                                  double rotation) :
         CUniformDiffuseCell(t_MaterialProperties, t_Cell, rotation),
         CDirectionalDiffuseCell(t_MaterialProperties, t_Cell, rotation)
     {}
 
-    std::shared_ptr<CVenetianCellDescription> CVenetianBase::getCellAsVenetian() const
+    const CVenetianCellDescription & CVenetianBase::getCellAsVenetian() const
     {
-        if(std::dynamic_pointer_cast<CVenetianCellDescription>(m_CellDescription) == nullptr)
-        {
-            assert("Incorrectly assigned cell description.");
-        }
-
-        std::shared_ptr<CVenetianCellDescription> aCell =
-          std::dynamic_pointer_cast<CVenetianCellDescription>(m_CellDescription);
-
-        return aCell;
+        assert(std::holds_alternative<CVenetianCellDescription>(m_CellDescription)
+               && "Incorrectly assigned cell description.");
+        return std::get<CVenetianCellDescription>(m_CellDescription);
     }
 
 
@@ -38,13 +32,12 @@ namespace SingleLayerOptics
     //  CVenetianCell
     ////////////////////////////////////////////////////////////////////////////////////////////
     CVenetianCell::CVenetianCell(const std::shared_ptr<CMaterial> & t_MaterialProperties,
-                                 const std::shared_ptr<ICellDescription> & t_Cell,
+                                 const CellDescription & t_Cell,
                                  const double rotation) :
         CBaseCell(t_MaterialProperties, t_Cell, rotation),
         CVenetianBase(t_MaterialProperties, t_Cell, rotation),
-        m_BackwardFlowCellDescription(getCellAsVenetian()->getBackwardFlowCell())
+        m_BackwardFlowCellDescription(getCellAsVenetian().getBackwardFlowCell())
     {
-        assert(t_Cell != nullptr);
         assert(t_MaterialProperties != nullptr);
 
         generateVenetianEnergy();

--- a/src/SingleLayerOptics/src/VenetianCell.cpp
+++ b/src/SingleLayerOptics/src/VenetianCell.cpp
@@ -35,8 +35,7 @@ namespace SingleLayerOptics
                                  const CellDescription & t_Cell,
                                  const double rotation) :
         CBaseCell(t_MaterialProperties, t_Cell, rotation),
-        CVenetianBase(t_MaterialProperties, t_Cell, rotation),
-        m_BackwardFlowCellDescription(getCellAsVenetian().getBackwardFlowCell())
+        CVenetianBase(t_MaterialProperties, t_Cell, rotation)
     {
         assert(t_MaterialProperties != nullptr);
 
@@ -45,9 +44,13 @@ namespace SingleLayerOptics
 
     void CVenetianCell::generateVenetianEnergy()
     {
-        const auto & venetianForwardGeometry{getCellAsVenetian()};
-        m_Energy =
-          CVenetianEnergy(*m_Material, venetianForwardGeometry, m_BackwardFlowCellDescription);
+        // Build the forward and backward geometry bundles once. The enclosure view factors and
+        // slat mesh depend only on geometry, so every band-wavelength CVenetianCellEnergy can
+        // share them — only the LayerProperties differ across the band.
+        auto forwardGeometry = makeVenetianGeometry(getCellAsVenetian());
+        auto backwardGeometry = makeVenetianGeometry(getCellAsVenetian().getBackwardFlowCell());
+
+        m_Energy = CVenetianEnergy(*m_Material, forwardGeometry, backwardGeometry);
         // Create energy states for entire material band
         m_EnergiesBand.clear();
         std::vector<RMaterialProperties> aMat = m_Material->getBandProperties();
@@ -62,9 +65,8 @@ namespace SingleLayerOptics
                 double Rf = aMat[i].getProperty(Property::R, Side::Front);
                 double Rb = aMat[i].getProperty(Property::R, Side::Back);
 
-                m_EnergiesBand.emplace_back(LayerProperties{Tf, Rf, Tb, Rb},
-                                            venetianForwardGeometry,
-                                            m_BackwardFlowCellDescription);
+                m_EnergiesBand.emplace_back(
+                  LayerProperties{Tf, Rf, Tb, Rb}, forwardGeometry, backwardGeometry);
             }
         }
     }

--- a/src/SingleLayerOptics/src/VenetianCell.hpp
+++ b/src/SingleLayerOptics/src/VenetianCell.hpp
@@ -7,6 +7,7 @@
 #include <WCECommon.hpp>
 
 #include "VenetianSegments.hpp"
+#include "VenetianCellDescription.hpp"
 #include "UniformDiffuseCell.hpp"
 #include "DirectionalDiffuseCell.hpp"
 #include "BeamDirection.hpp"
@@ -20,25 +21,22 @@ namespace FenestrationCommon
 
 namespace SingleLayerOptics
 {
-    class ICellDescription;
-    class CVenetianCellDescription;
-
     class CVenetianBase : public CUniformDiffuseCell, public CDirectionalDiffuseCell
     {
     public:
         CVenetianBase(const std::shared_ptr<CMaterial> & t_MaterialProperties,
-                      const std::shared_ptr<ICellDescription> & t_Cell,
+                      const CellDescription & t_Cell,
                       double rotation = 0);
 
     protected:
-        [[nodiscard]] std::shared_ptr<CVenetianCellDescription> getCellAsVenetian() const;
+        [[nodiscard]] const CVenetianCellDescription & getCellAsVenetian() const;
     };
 
     class CVenetianCell : public CVenetianBase
     {
     public:
         CVenetianCell(const std::shared_ptr<CMaterial> & t_MaterialProperties,
-                      const std::shared_ptr<ICellDescription> & t_Cell,
+                      const CellDescription & t_Cell,
                       double rotation = 0);
 
         void setSourceData(const FenestrationCommon::CSeries & t_SourceData) override;
@@ -114,7 +112,7 @@ namespace SingleLayerOptics
         // Energy calculations for material range (wavelengths)
         std::vector<CVenetianEnergy> m_EnergiesBand;
 
-        std::shared_ptr<CVenetianCellDescription> m_BackwardFlowCellDescription;
+        CVenetianCellDescription m_BackwardFlowCellDescription;
     };
 
 }   // namespace SingleLayerOptics

--- a/src/SingleLayerOptics/src/VenetianCell.hpp
+++ b/src/SingleLayerOptics/src/VenetianCell.hpp
@@ -111,8 +111,6 @@ namespace SingleLayerOptics
 
         // Energy calculations for material range (wavelengths)
         std::vector<CVenetianEnergy> m_EnergiesBand;
-
-        CVenetianCellDescription m_BackwardFlowCellDescription;
     };
 
 }   // namespace SingleLayerOptics

--- a/src/SingleLayerOptics/src/VenetianCellDescription.cpp
+++ b/src/SingleLayerOptics/src/VenetianCellDescription.cpp
@@ -78,20 +78,19 @@ namespace SingleLayerOptics
         return Helper::getSegmentProperty(m_Geometry, Index, &Viewer::CSegment2D::angle);
     }
 
-    std::shared_ptr<CVenetianCellDescription> CVenetianCellDescription::getBackwardFlowCell() const
+    CVenetianCellDescription CVenetianCellDescription::getBackwardFlowCell() const
     {
         auto venetianGeometry{m_VenetianGeometry};
         venetianGeometry.SlatTiltAngle = -venetianGeometry.SlatTiltAngle;
         size_t m_NumOfSlatSegments = m_Top.segments().size();
 
-        std::shared_ptr<CVenetianCellDescription> aBackwardCell =
-          std::make_shared<CVenetianCellDescription>(venetianGeometry, m_NumOfSlatSegments);
+        CVenetianCellDescription aBackwardCell{venetianGeometry, m_NumOfSlatSegments};
 
         if(!m_ProfileAngles.empty())
         {
-            aBackwardCell->preCalculateForProfileAngles(
+            aBackwardCell.preCalculateForProfileAngles(
               FenestrationCommon::Side::Front, m_ProfileAngles.at(FenestrationCommon::Side::Back));
-            aBackwardCell->preCalculateForProfileAngles(
+            aBackwardCell.preCalculateForProfileAngles(
               FenestrationCommon::Side::Back, m_ProfileAngles.at(FenestrationCommon::Side::Front));
         }
         return aBackwardCell;

--- a/src/SingleLayerOptics/src/VenetianCellDescription.hpp
+++ b/src/SingleLayerOptics/src/VenetianCellDescription.hpp
@@ -6,9 +6,8 @@
 #include <WCECommon.hpp>
 #include <WCEViewer.hpp>
 
-#include "CellDescription.hpp"
 #include "VenetianSlat.hpp"
-#include "VenetianSegments.hpp"
+#include "VenetianSegmentsTypes.hpp"
 #include "BSDFDirections.hpp"
 
 namespace SingleLayerOptics
@@ -19,16 +18,14 @@ namespace SingleLayerOptics
         Bottom = 1
     };
 
-    class CVenetianCellDescription : public ICellDescription
+    class CVenetianCellDescription
     {
     public:
-        virtual ~CVenetianCellDescription() = default;
-
         CVenetianCellDescription(const FenestrationCommon::Venetian::Geometry & t_Geometry,
                                  size_t t_NumOfSlatSegments);
 
         // Makes exact copy of cell description
-        [[nodiscard]] std::shared_ptr<CVenetianCellDescription> getBackwardFlowCell() const;
+        [[nodiscard]] CVenetianCellDescription getBackwardFlowCell() const;
         [[nodiscard]] size_t numberOfSegments() const;
         [[nodiscard]] double segmentLength(size_t Index) const;
         [[nodiscard]] double segmentAngle(size_t Index) const;
@@ -66,8 +63,7 @@ namespace SingleLayerOptics
                                                                 const CBeamDirection & t_Direction);
 
         // Direct to direct component of the ray
-        double Beam_dir_dir(FenestrationCommon::Side t_Side,
-                            const CBeamDirection & t_Direction) override;
+        double Beam_dir_dir(FenestrationCommon::Side t_Side, const CBeamDirection & t_Direction);
 
         [[nodiscard]] FenestrationCommon::Venetian::Geometry getVenetianGeometry() const;
         [[nodiscard]] size_t numOfSegments() const;

--- a/src/SingleLayerOptics/src/VenetianSegments.cpp
+++ b/src/SingleLayerOptics/src/VenetianSegments.cpp
@@ -18,54 +18,62 @@ namespace SingleLayerOptics
 
     using namespace FenestrationCommon;
 
+    std::shared_ptr<VenetianGeometry> makeVenetianGeometry(CVenetianCellDescription t_Cell)
+    {
+        auto viewFactors = t_Cell.viewFactors();
+        SlatSegmentsMesh mesh(t_Cell);
+        return std::make_shared<VenetianGeometry>(
+          VenetianGeometry{std::move(t_Cell), std::move(viewFactors), std::move(mesh)});
+    }
+
     ////////////////////////////////////////////////////////////////////////////////////////////
     ///  CVenetianCellEnergy
     ////////////////////////////////////////////////////////////////////////////////////////////
     CVenetianCellEnergy::CVenetianCellEnergy() : m_LayerProperties({})
     {}
 
-    CVenetianCellEnergy::CVenetianCellEnergy(
-      const CVenetianCellDescription & t_Cell,
-      const LayerProperties & properties) :
-        m_Cell(t_Cell),
+    CVenetianCellEnergy::CVenetianCellEnergy(std::shared_ptr<VenetianGeometry> t_Geometry,
+                                             const LayerProperties & properties) :
+        m_Geometry(std::move(t_Geometry)),
         m_LayerProperties(properties),
-        m_SlatSegmentsMesh(*m_Cell),
-        slatsDiffuseRadiancesMatrix(formIrradianceMatrix(m_Cell->viewFactors(), m_LayerProperties))
+        slatsDiffuseRadiancesMatrix(
+          formIrradianceMatrix(m_Geometry->viewFactors, m_LayerProperties))
     {}
 
     double CVenetianCellEnergy::T_dir_dir(const CBeamDirection & t_Direction)
     {
-        return m_Cell->Beam_dir_dir(Side::Front, t_Direction);
+        return m_Geometry->cell.Beam_dir_dir(Side::Front, t_Direction);
     }
 
     double CVenetianCellEnergy::T_dir_dif(const CBeamDirection & t_Direction)
     {
+        const auto & mesh = m_Geometry->mesh;
         if(!m_DirectToDiffuseSlatIrradiances.count(t_Direction))
         {
             const auto diffuseViewFactors{
-              beamToDiffuseViewFactors(Side::Front, t_Direction, *m_Cell, m_SlatSegmentsMesh)};
+              beamToDiffuseViewFactors(Side::Front, t_Direction, m_Geometry->cell, mesh)};
 
             const auto irradiance =
-              slatIrradiances(diffuseViewFactors, slatsDiffuseRadiancesMatrix, m_SlatSegmentsMesh);
+              slatIrradiances(diffuseViewFactors, slatsDiffuseRadiancesMatrix, mesh);
             std::lock_guard lock(irradianceMutex);
             m_DirectToDiffuseSlatIrradiances[t_Direction] = irradiance;
         }
 
         // Total energy accounts for direct to direct component. That needs to be subtracted since
         // only direct to diffuse is of interest
-        return m_DirectToDiffuseSlatIrradiances.at(t_Direction)[m_SlatSegmentsMesh.numberOfSegments]
-                 .E_f
+        return m_DirectToDiffuseSlatIrradiances.at(t_Direction)[mesh.numberOfSegments].E_f
                - T_dir_dir(t_Direction);
     }
 
     double CVenetianCellEnergy::R_dir_dif(const CBeamDirection & t_Direction)
     {
+        const auto & mesh = m_Geometry->mesh;
         if(!m_DirectToDiffuseSlatIrradiances.count(t_Direction))
         {
             const auto diffuseViewFactors{
-              beamToDiffuseViewFactors(Side::Back, t_Direction, *m_Cell, m_SlatSegmentsMesh)};
+              beamToDiffuseViewFactors(Side::Back, t_Direction, m_Geometry->cell, mesh)};
             const auto irradiance =
-              slatIrradiances(diffuseViewFactors, slatsDiffuseRadiancesMatrix, m_SlatSegmentsMesh);
+              slatIrradiances(diffuseViewFactors, slatsDiffuseRadiancesMatrix, mesh);
             std::lock_guard lock(irradianceMutex);
             m_DirectToDiffuseSlatIrradiances[t_Direction] = irradiance;
         }
@@ -112,10 +120,10 @@ namespace SingleLayerOptics
                                                      const CBeamDirection & t_OutgoingDirection,
                                                      const std::vector<double> & slatRadiances)
     {
-        const auto visibleFraction = m_Cell->visibleBeamSegmentFractionSlatsOnly(
+        const auto visibleFraction = m_Geometry->cell.visibleBeamSegmentFractionSlatsOnly(
           side, BSDFDirection::Outgoing, t_OutgoingDirection);
 
-        const auto slats = m_Cell->getSlats();
+        const auto slats = m_Geometry->cell.getSlats();
 
         assert(slatRadiances.size() == visibleFraction.size()
                && slatRadiances.size() == slats.size());
@@ -131,28 +139,28 @@ namespace SingleLayerOptics
         }
 
         return aResult
-               / (WCE_PI * m_Cell->getCellSpacing()
+               / (WCE_PI * m_Geometry->cell.getCellSpacing()
                   * cos(radians(t_OutgoingDirection.profileAngle())));
     }
 
     double CVenetianCellEnergy::T_dif_dif()
     {
-        auto B{diffuseRadiosities(m_SlatSegmentsMesh.numberOfSegments,
-                                  m_SlatSegmentsMesh.surfaceIndexes,
-                                  m_Cell->viewFactors())};
+        const auto & mesh = m_Geometry->mesh;
+        auto B{
+          diffuseRadiosities(mesh.numberOfSegments, mesh.surfaceIndexes, m_Geometry->viewFactors)};
 
-        return solveSystem(slatsDiffuseRadiancesMatrix, B)[m_SlatSegmentsMesh.numberOfSegments - 1];
+        return solveSystem(slatsDiffuseRadiancesMatrix, B)[mesh.numberOfSegments - 1];
     }
 
     double CVenetianCellEnergy::R_dif_dif()
     {
-        auto B{diffuseRadiosities(m_SlatSegmentsMesh.numberOfSegments,
-                                  m_SlatSegmentsMesh.surfaceIndexes,
-                                  m_Cell->viewFactors())};
+        const auto & mesh = m_Geometry->mesh;
+        auto B{
+          diffuseRadiosities(mesh.numberOfSegments, mesh.surfaceIndexes, m_Geometry->viewFactors)};
 
         std::vector<double> aSolution = solveSystem(slatsDiffuseRadiancesMatrix, B);
 
-        return aSolution[m_SlatSegmentsMesh.numberOfSegments];
+        return aSolution[mesh.numberOfSegments];
     }
 
     SlatSegmentsMesh::SlatSegmentsMesh(CVenetianCellDescription & cell) :
@@ -348,19 +356,19 @@ namespace SingleLayerOptics
     FenestrationCommon::SquareMatrix CVenetianCellEnergy::formIrradianceMatrix(
       const FenestrationCommon::SquareMatrix & viewFactors, const LayerProperties & properties)
     {
-        size_t numSeg = m_SlatSegmentsMesh.numberOfSegments;
+        const auto & mesh = m_Geometry->mesh;
+        size_t numSeg = mesh.numberOfSegments;
         SquareMatrix energy{2 * numSeg};
 
         auto fillUpperLeft = [&](size_t i, size_t j) -> double {
             if(i != numSeg - 1)
             {
-                double value =
-                  viewFactors(m_SlatSegmentsMesh.surfaceIndexes.backSideMeshIndex[i + 1],
-                              m_SlatSegmentsMesh.surfaceIndexes.frontSideMeshIndex[j])
-                    * properties.Tf
-                  + viewFactors(m_SlatSegmentsMesh.surfaceIndexes.frontSideMeshIndex[i],
-                                m_SlatSegmentsMesh.surfaceIndexes.frontSideMeshIndex[j])
-                      * properties.Rf;
+                double value = viewFactors(mesh.surfaceIndexes.backSideMeshIndex[i + 1],
+                                           mesh.surfaceIndexes.frontSideMeshIndex[j])
+                                 * properties.Tf
+                               + viewFactors(mesh.surfaceIndexes.frontSideMeshIndex[i],
+                                             mesh.surfaceIndexes.frontSideMeshIndex[j])
+                                   * properties.Rf;
                 if(i == j)
                 {
                     value -= 1;
@@ -373,11 +381,11 @@ namespace SingleLayerOptics
         auto fillLowerLeft = [&](size_t i, size_t j) -> double {
             if(i != numSeg - 1)
             {
-                return viewFactors(m_SlatSegmentsMesh.surfaceIndexes.backSideMeshIndex[i + 1],
-                                   m_SlatSegmentsMesh.surfaceIndexes.backSideMeshIndex[j])
+                return viewFactors(mesh.surfaceIndexes.backSideMeshIndex[i + 1],
+                                   mesh.surfaceIndexes.backSideMeshIndex[j])
                          * properties.Tf
-                       + viewFactors(m_SlatSegmentsMesh.surfaceIndexes.frontSideMeshIndex[i],
-                                     m_SlatSegmentsMesh.surfaceIndexes.backSideMeshIndex[j])
+                       + viewFactors(mesh.surfaceIndexes.frontSideMeshIndex[i],
+                                     mesh.surfaceIndexes.backSideMeshIndex[j])
                            * properties.Rf;
             }
             return 0.0;
@@ -386,11 +394,11 @@ namespace SingleLayerOptics
         auto fillUpperRight = [&](size_t i, size_t j) -> double {
             if(i != 0)
             {
-                return viewFactors(m_SlatSegmentsMesh.surfaceIndexes.frontSideMeshIndex[i - 1],
-                                   m_SlatSegmentsMesh.surfaceIndexes.frontSideMeshIndex[j])
+                return viewFactors(mesh.surfaceIndexes.frontSideMeshIndex[i - 1],
+                                   mesh.surfaceIndexes.frontSideMeshIndex[j])
                          * properties.Tb
-                       + viewFactors(m_SlatSegmentsMesh.surfaceIndexes.backSideMeshIndex[i],
-                                     m_SlatSegmentsMesh.surfaceIndexes.frontSideMeshIndex[j])
+                       + viewFactors(mesh.surfaceIndexes.backSideMeshIndex[i],
+                                     mesh.surfaceIndexes.frontSideMeshIndex[j])
                            * properties.Rb;
             }
             return 0.0;
@@ -399,13 +407,12 @@ namespace SingleLayerOptics
         auto fillLowerRight = [&](size_t i, size_t j) -> double {
             if(i != 0)
             {
-                double value =
-                  viewFactors(m_SlatSegmentsMesh.surfaceIndexes.frontSideMeshIndex[i - 1],
-                              m_SlatSegmentsMesh.surfaceIndexes.backSideMeshIndex[j])
-                    * properties.Tb
-                  + viewFactors(m_SlatSegmentsMesh.surfaceIndexes.backSideMeshIndex[i],
-                                m_SlatSegmentsMesh.surfaceIndexes.backSideMeshIndex[j])
-                      * properties.Rb;
+                double value = viewFactors(mesh.surfaceIndexes.frontSideMeshIndex[i - 1],
+                                           mesh.surfaceIndexes.backSideMeshIndex[j])
+                                 * properties.Tb
+                               + viewFactors(mesh.surfaceIndexes.backSideMeshIndex[i],
+                                             mesh.surfaceIndexes.backSideMeshIndex[j])
+                                   * properties.Rb;
                 if(i == j)
                 {
                     value -= 1;
@@ -479,18 +486,19 @@ namespace SingleLayerOptics
       CVenetianCellEnergy::directToDirectSlatIrradiances(const CBeamDirection & t_IncomingDirection)
     {
         using SingleLayerOptics::SlatPosition;
+        auto & cell = m_Geometry->cell;
         //! Irradiances are always calculated from the front side perspective
         const auto vf{
-          m_Cell->cellBeamViewFactors(Side::Front, BSDFDirection::Incoming, t_IncomingDirection)};
+          cell.cellBeamViewFactors(Side::Front, BSDFDirection::Incoming, t_IncomingDirection)};
 
         const auto upperSlatIrradiances{Helper::slatIrradiancesFromBeam(
           Helper::filterByEnclosureIndex(vf, SingleLayerOptics::SlatPosition::Top),
-          m_Cell->getSlats(SlatPosition::Top),
+          cell.getSlats(SlatPosition::Top),
           t_IncomingDirection)};
 
         const auto lowerSlatIrradiances{Helper::slatIrradiancesFromBeam(
           Helper::filterByEnclosureIndex(vf, SingleLayerOptics::SlatPosition::Bottom),
-          m_Cell->getSlats(SlatPosition::Bottom),
+          cell.getSlats(SlatPosition::Bottom),
           t_IncomingDirection)};
 
         // They must be of the same size
@@ -536,27 +544,26 @@ namespace SingleLayerOptics
     CVenetianEnergy::CVenetianEnergy()
     {}
 
-    CVenetianEnergy::CVenetianEnergy(
-      const CMaterial & t_Material,
-      const CVenetianCellDescription & t_ForwardFlowGeometry,
-      const CVenetianCellDescription & t_BackwardFlowGeometry)
+    CVenetianEnergy::CVenetianEnergy(const CMaterial & t_Material,
+                                     std::shared_ptr<VenetianGeometry> t_ForwardFlowGeometry,
+                                     std::shared_ptr<VenetianGeometry> t_BackwardFlowGeometry)
     {
         // clang-format off
         createForwardAndBackward({t_Material.getProperty(Property::T, Side::Front),
                                   t_Material.getProperty(Property::R, Side::Front),
                                   t_Material.getProperty(Property::T, Side::Back),
                                   t_Material.getProperty(Property::R, Side::Back)},
-                                    t_ForwardFlowGeometry,
-                                    t_BackwardFlowGeometry);
+                                    std::move(t_ForwardFlowGeometry),
+                                    std::move(t_BackwardFlowGeometry));
         // clang-format on
     }
 
-    CVenetianEnergy::CVenetianEnergy(
-      const LayerProperties & properties,
-      const CVenetianCellDescription & t_ForwardFlowGeometry,
-      const CVenetianCellDescription & t_BackwardFlowGeometry)
+    CVenetianEnergy::CVenetianEnergy(const LayerProperties & properties,
+                                     std::shared_ptr<VenetianGeometry> t_ForwardFlowGeometry,
+                                     std::shared_ptr<VenetianGeometry> t_BackwardFlowGeometry)
     {
-        createForwardAndBackward(properties, t_ForwardFlowGeometry, t_BackwardFlowGeometry);
+        createForwardAndBackward(
+          properties, std::move(t_ForwardFlowGeometry), std::move(t_BackwardFlowGeometry));
     }
 
     CVenetianCellEnergy & CVenetianEnergy::getCell(const Side t_Side)
@@ -566,10 +573,12 @@ namespace SingleLayerOptics
 
     void CVenetianEnergy::createForwardAndBackward(
       const LayerProperties & layerProperties,
-      const CVenetianCellDescription & t_ForwardFlowGeometry,
-      const CVenetianCellDescription & t_BackwardFlowGeometry)
+      std::shared_ptr<VenetianGeometry> t_ForwardFlowGeometry,
+      std::shared_ptr<VenetianGeometry> t_BackwardFlowGeometry)
     {
-        m_CellEnergy[Side::Front] = CVenetianCellEnergy(t_ForwardFlowGeometry, layerProperties);
-        m_CellEnergy[Side::Back] = CVenetianCellEnergy(t_BackwardFlowGeometry, layerProperties);
+        m_CellEnergy[Side::Front] =
+          CVenetianCellEnergy(std::move(t_ForwardFlowGeometry), layerProperties);
+        m_CellEnergy[Side::Back] =
+          CVenetianCellEnergy(std::move(t_BackwardFlowGeometry), layerProperties);
     }
 }   // namespace SingleLayerOptics

--- a/src/SingleLayerOptics/src/VenetianSegments.cpp
+++ b/src/SingleLayerOptics/src/VenetianSegments.cpp
@@ -21,11 +21,11 @@ namespace SingleLayerOptics
     ////////////////////////////////////////////////////////////////////////////////////////////
     ///  CVenetianCellEnergy
     ////////////////////////////////////////////////////////////////////////////////////////////
-    CVenetianCellEnergy::CVenetianCellEnergy() : m_Cell(nullptr), m_LayerProperties({})
+    CVenetianCellEnergy::CVenetianCellEnergy() : m_LayerProperties({})
     {}
 
     CVenetianCellEnergy::CVenetianCellEnergy(
-      const std::shared_ptr<CVenetianCellDescription> & t_Cell,
+      const CVenetianCellDescription & t_Cell,
       const LayerProperties & properties) :
         m_Cell(t_Cell),
         m_LayerProperties(properties),
@@ -538,8 +538,8 @@ namespace SingleLayerOptics
 
     CVenetianEnergy::CVenetianEnergy(
       const CMaterial & t_Material,
-      const std::shared_ptr<CVenetianCellDescription> & t_ForwardFlowGeometry,
-      const std::shared_ptr<CVenetianCellDescription> & t_BackwardFlowGeometry)
+      const CVenetianCellDescription & t_ForwardFlowGeometry,
+      const CVenetianCellDescription & t_BackwardFlowGeometry)
     {
         // clang-format off
         createForwardAndBackward({t_Material.getProperty(Property::T, Side::Front),
@@ -553,8 +553,8 @@ namespace SingleLayerOptics
 
     CVenetianEnergy::CVenetianEnergy(
       const LayerProperties & properties,
-      const std::shared_ptr<CVenetianCellDescription> & t_ForwardFlowGeometry,
-      const std::shared_ptr<CVenetianCellDescription> & t_BackwardFlowGeometry)
+      const CVenetianCellDescription & t_ForwardFlowGeometry,
+      const CVenetianCellDescription & t_BackwardFlowGeometry)
     {
         createForwardAndBackward(properties, t_ForwardFlowGeometry, t_BackwardFlowGeometry);
     }
@@ -566,11 +566,9 @@ namespace SingleLayerOptics
 
     void CVenetianEnergy::createForwardAndBackward(
       const LayerProperties & layerProperties,
-      const std::shared_ptr<CVenetianCellDescription> & t_ForwardFlowGeometry,
-      const std::shared_ptr<CVenetianCellDescription> & t_BackwardFlowGeometry)
+      const CVenetianCellDescription & t_ForwardFlowGeometry,
+      const CVenetianCellDescription & t_BackwardFlowGeometry)
     {
-        assert(t_ForwardFlowGeometry != nullptr);
-        assert(t_BackwardFlowGeometry != nullptr);
         m_CellEnergy[Side::Front] = CVenetianCellEnergy(t_ForwardFlowGeometry, layerProperties);
         m_CellEnergy[Side::Back] = CVenetianCellEnergy(t_BackwardFlowGeometry, layerProperties);
     }

--- a/src/SingleLayerOptics/src/VenetianSegments.hpp
+++ b/src/SingleLayerOptics/src/VenetianSegments.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <optional>
+#include <memory>
 
 #include "VenetianSegmentsTypes.hpp"
 #include "VenetianCellDescription.hpp"
@@ -99,12 +99,26 @@ namespace SingleLayerOptics
                                  const FenestrationCommon::SquareMatrix & radiancesMatrix,
                                  const LayerProperties & properties);
 
+    //! Geometry-only bundle shared by every CVenetianCellEnergy built from the same cell
+    //! description. The enclosure view-factor matrix and the slat mesh depend only on the
+    //! geometry, so they are computed once here and reused across the band (where only the
+    //! per-wavelength LayerProperties differ).
+    struct VenetianGeometry
+    {
+        CVenetianCellDescription cell;
+        FenestrationCommon::SquareMatrix viewFactors;
+        SlatSegmentsMesh mesh;
+    };
+
+    [[nodiscard]] std::shared_ptr<VenetianGeometry>
+      makeVenetianGeometry(CVenetianCellDescription t_Cell);
+
     // Keeping intermediate results for backward and forward directions.
     class CVenetianCellEnergy
     {
     public:
         CVenetianCellEnergy();
-        CVenetianCellEnergy(const CVenetianCellDescription & t_Cell,
+        CVenetianCellEnergy(std::shared_ptr<VenetianGeometry> t_Geometry,
                             const LayerProperties & layerProperties);
 
         double T_dir_dir(const CBeamDirection & t_Direction);
@@ -141,10 +155,8 @@ namespace SingleLayerOptics
                                          const CBeamDirection & t_OutgoingDirection,
                                          const std::vector<double> & slatRadiances);
 
-        std::optional<CVenetianCellDescription> m_Cell;
+        std::shared_ptr<VenetianGeometry> m_Geometry;
         LayerProperties m_LayerProperties;
-
-        SlatSegmentsMesh m_SlatSegmentsMesh;
 
         //! This matrix is precalculated for the diffuse to diffuse part of the calculation.
         //! It is used to calculate the radiances for the slats and it is precalculated because it
@@ -163,12 +175,12 @@ namespace SingleLayerOptics
     public:
         CVenetianEnergy();
         CVenetianEnergy(const CMaterial & t_Material,
-                        const CVenetianCellDescription & t_ForwardFlowGeometry,
-                        const CVenetianCellDescription & t_BackwardFlowGeometry);
+                        std::shared_ptr<VenetianGeometry> t_ForwardFlowGeometry,
+                        std::shared_ptr<VenetianGeometry> t_BackwardFlowGeometry);
 
         CVenetianEnergy(const LayerProperties & layerProperties,
-                        const CVenetianCellDescription & t_ForwardFlowGeometry,
-                        const CVenetianCellDescription & t_BackwardFlowGeometry);
+                        std::shared_ptr<VenetianGeometry> t_ForwardFlowGeometry,
+                        std::shared_ptr<VenetianGeometry> t_BackwardFlowGeometry);
 
         [[nodiscard]] CVenetianCellEnergy & getCell(FenestrationCommon::Side t_Side);
 
@@ -176,8 +188,8 @@ namespace SingleLayerOptics
         // construction of forward and backward cells from both constructors have identical part of
         // the code
         void createForwardAndBackward(const LayerProperties & layerProperties,
-                                      const CVenetianCellDescription & t_ForwardFlowGeometry,
-                                      const CVenetianCellDescription & t_BackwardFlowGeometry);
+                                      std::shared_ptr<VenetianGeometry> t_ForwardFlowGeometry,
+                                      std::shared_ptr<VenetianGeometry> t_BackwardFlowGeometry);
 
         std::map<FenestrationCommon::Side, CVenetianCellEnergy> m_CellEnergy;
     };

--- a/src/SingleLayerOptics/src/VenetianSegments.hpp
+++ b/src/SingleLayerOptics/src/VenetianSegments.hpp
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <optional>
+
+#include "VenetianSegmentsTypes.hpp"
+#include "VenetianCellDescription.hpp"
+
 namespace Viewer
 {
     struct BeamViewFactor;
@@ -8,7 +13,6 @@ namespace Viewer
 
 namespace SingleLayerOptics
 {
-    class CVenetianCellDescription;
     class CBeamDirection;
     class CMaterial;
 
@@ -17,19 +21,6 @@ namespace SingleLayerOptics
     {
         double E_f{0.0};
         double E_b{0.0};
-    };
-
-    //! Keeps information about beam view factor and percentage view. Incoming beam value is
-    //! normalized to one.
-    //! @viewFactor Fraction of the incoming beam that slat is being hit with
-    //! @percentViewed Incoming beam will not always fully hit the slat. This is the percentage
-    //! of the slat that actually is being hit by the beam.
-    struct BeamSegmentView
-    {
-        BeamSegmentView() : viewFactor(0), percentViewed(0)
-        {}
-        double viewFactor;
-        double percentViewed;
     };
 
     struct SegmentIndexes
@@ -113,7 +104,7 @@ namespace SingleLayerOptics
     {
     public:
         CVenetianCellEnergy();
-        CVenetianCellEnergy(const std::shared_ptr<CVenetianCellDescription> & t_Cell,
+        CVenetianCellEnergy(const CVenetianCellDescription & t_Cell,
                             const LayerProperties & layerProperties);
 
         double T_dir_dir(const CBeamDirection & t_Direction);
@@ -150,7 +141,7 @@ namespace SingleLayerOptics
                                          const CBeamDirection & t_OutgoingDirection,
                                          const std::vector<double> & slatRadiances);
 
-        std::shared_ptr<CVenetianCellDescription> m_Cell;
+        std::optional<CVenetianCellDescription> m_Cell;
         LayerProperties m_LayerProperties;
 
         SlatSegmentsMesh m_SlatSegmentsMesh;
@@ -172,22 +163,21 @@ namespace SingleLayerOptics
     public:
         CVenetianEnergy();
         CVenetianEnergy(const CMaterial & t_Material,
-                        const std::shared_ptr<CVenetianCellDescription> & t_ForwardFlowGeometry,
-                        const std::shared_ptr<CVenetianCellDescription> & t_BackwardFlowGeometry);
+                        const CVenetianCellDescription & t_ForwardFlowGeometry,
+                        const CVenetianCellDescription & t_BackwardFlowGeometry);
 
         CVenetianEnergy(const LayerProperties & layerProperties,
-                        const std::shared_ptr<CVenetianCellDescription> & t_ForwardFlowGeometry,
-                        const std::shared_ptr<CVenetianCellDescription> & t_BackwardFlowGeometry);
+                        const CVenetianCellDescription & t_ForwardFlowGeometry,
+                        const CVenetianCellDescription & t_BackwardFlowGeometry);
 
         [[nodiscard]] CVenetianCellEnergy & getCell(FenestrationCommon::Side t_Side);
 
     private:
         // construction of forward and backward cells from both constructors have identical part of
         // the code
-        void createForwardAndBackward(
-          const LayerProperties & layerProperties,
-          const std::shared_ptr<CVenetianCellDescription> & t_ForwardFlowGeometry,
-          const std::shared_ptr<CVenetianCellDescription> & t_BackwardFlowGeometry);
+        void createForwardAndBackward(const LayerProperties & layerProperties,
+                                      const CVenetianCellDescription & t_ForwardFlowGeometry,
+                                      const CVenetianCellDescription & t_BackwardFlowGeometry);
 
         std::map<FenestrationCommon::Side, CVenetianCellEnergy> m_CellEnergy;
     };

--- a/src/SingleLayerOptics/src/VenetianSegmentsTypes.hpp
+++ b/src/SingleLayerOptics/src/VenetianSegmentsTypes.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace SingleLayerOptics
+{
+    //! Keeps information about beam view factor and percentage view. Incoming beam value is
+    //! normalized to one.
+    //! @viewFactor Fraction of the incoming beam that slat is being hit with
+    //! @percentViewed Incoming beam will not always fully hit the slat. This is the percentage
+    //! of the slat that actually is being hit by the beam.
+    struct BeamSegmentView
+    {
+        BeamSegmentView() : viewFactor(0), percentViewed(0)
+        {}
+        double viewFactor;
+        double percentViewed;
+    };
+}   // namespace SingleLayerOptics

--- a/src/SingleLayerOptics/src/WovenCell.cpp
+++ b/src/SingleLayerOptics/src/WovenCell.cpp
@@ -64,7 +64,7 @@ namespace SingleLayerOptics
     //  CWovenCell
     ////////////////////////////////////////////////////////////////////////////////////////////
     CWovenCell::CWovenCell(const std::shared_ptr<CMaterial> & t_MaterialProperties,
-                           const std::shared_ptr<ICellDescription> & t_Cell) :
+                           const CellDescription & t_Cell) :
         CBaseCell(t_MaterialProperties, t_Cell), CUniformDiffuseCell(t_MaterialProperties, t_Cell)
     {}
 
@@ -137,17 +137,11 @@ namespace SingleLayerOptics
         return Rmaterial - Tsct;
     }
 
-    std::shared_ptr<CWovenCellDescription> CWovenCell::getCellAsWoven() const
+    const CWovenCellDescription & CWovenCell::getCellAsWoven() const
     {
-        if(std::dynamic_pointer_cast<CWovenCellDescription>(m_CellDescription) == nullptr)
-        {
-            assert("Incorrectly assigned cell description.");
-        }
-
-        std::shared_ptr<CWovenCellDescription> aCell =
-          std::dynamic_pointer_cast<CWovenCellDescription>(m_CellDescription);
-
-        return aCell;
+        assert(std::holds_alternative<CWovenCellDescription>(m_CellDescription)
+               && "Incorrectly assigned cell description.");
+        return std::get<CWovenCellDescription>(m_CellDescription);
     }
 
     double CWovenCell::Tscatter_single(const Side t_Side, const CBeamDirection & t_Direction) const
@@ -155,7 +149,7 @@ namespace SingleLayerOptics
         // Get matterial property from the opposite side of woven thread
         Side aScatterSide = oppositeSide(t_Side);
         double RScatter_mat = m_Material->getProperty(Property::R, aScatterSide);
-        return Helper::Tscatter(getCellAsWoven()->gamma(), t_Direction, RScatter_mat);
+        return Helper::Tscatter(getCellAsWoven().gamma(), t_Direction, RScatter_mat);
     }
 
     std::vector<double> CWovenCell::T_scatter_band(const Side t_Side,
@@ -164,7 +158,7 @@ namespace SingleLayerOptics
         auto RScatterMat{m_Material->getBandProperties(Property::R, oppositeSide(t_Side))};
         std::vector<double> result(RScatterMat.size());
         std::ranges::transform(RScatterMat, result.begin(), [&](double r) {
-            return Helper::Tscatter(getCellAsWoven()->gamma(), t_Direction, r);
+            return Helper::Tscatter(getCellAsWoven().gamma(), t_Direction, r);
         });
         return result;
     }
@@ -174,6 +168,6 @@ namespace SingleLayerOptics
                                               size_t i) const
     {
         const auto & Rband = m_Material->getBandProperties(Property::R, oppositeSide(t_Side));
-        return Helper::Tscatter(getCellAsWoven()->gamma(), t_Direction, Rband[i]);
+        return Helper::Tscatter(getCellAsWoven().gamma(), t_Direction, Rband[i]);
     }
 }   // namespace SingleLayerOptics

--- a/src/SingleLayerOptics/src/WovenCell.hpp
+++ b/src/SingleLayerOptics/src/WovenCell.hpp
@@ -7,14 +7,13 @@
 namespace SingleLayerOptics
 {
     class CWovenCellDescription;
-    class ICellDescription;
     class CBeamDirection;
 
     class CWovenCell : public CUniformDiffuseCell
     {
     public:
         CWovenCell(const std::shared_ptr<CMaterial> & t_MaterialProperties,
-                   const std::shared_ptr<ICellDescription> & t_Cell);
+                   const CellDescription & t_Cell);
 
         double T_dir_dif(FenestrationCommon::Side t_Side,
                          const CBeamDirection & t_Direction) override;
@@ -34,7 +33,7 @@ namespace SingleLayerOptics
                                        size_t wavelengthIndex) override;
 
     private:
-        std::shared_ptr<CWovenCellDescription> getCellAsWoven() const;
+        const CWovenCellDescription & getCellAsWoven() const;
 
         double Tscatter_single(FenestrationCommon::Side t_Side,
                                const CBeamDirection & t_Direction) const;

--- a/src/SingleLayerOptics/src/WovenCellDescription.cpp
+++ b/src/SingleLayerOptics/src/WovenCellDescription.cpp
@@ -12,7 +12,7 @@ using namespace FenestrationCommon;
 namespace SingleLayerOptics
 {
     CWovenCellDescription::CWovenCellDescription(const double t_Diameter, const double t_Spacing) :
-        ICellDescription(), m_Diameter(t_Diameter), m_Spacing(t_Spacing)
+        m_Diameter(t_Diameter), m_Spacing(t_Spacing)
     {
         if(m_Diameter <= 0)
         {

--- a/src/SingleLayerOptics/src/WovenCellDescription.hpp
+++ b/src/SingleLayerOptics/src/WovenCellDescription.hpp
@@ -1,19 +1,22 @@
 #pragma once
 
-#include "CellDescription.hpp"
+namespace FenestrationCommon
+{
+    enum class Side;
+}
 
 namespace SingleLayerOptics
 {
-    class CWovenCellDescription : public ICellDescription
+    class CBeamDirection;
+
+    class CWovenCellDescription
     {
     public:
-        virtual ~CWovenCellDescription() = default;
-        CWovenCellDescription(const double t_Diameter, const double t_Spacing);
+        CWovenCellDescription(double t_Diameter, double t_Spacing);
 
         double gamma() const;
 
-        double Beam_dir_dir(const FenestrationCommon::Side t_Side,
-                            const CBeamDirection & t_Direction) override;
+        double Beam_dir_dir(FenestrationCommon::Side t_Side, const CBeamDirection & t_Direction);
 
         [[nodiscard]] double diameter() const;
         [[nodiscard]] double spacing() const;

--- a/src/SingleLayerOptics/tst/units/CircularPerforatedCell.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/CircularPerforatedCell.unit.cpp
@@ -30,7 +30,7 @@ protected:
         const auto radius = 5;      // mm
         m_DescriptionCell = std::make_shared<CCircularCellDescription>(x, y, thickness, radius);
 
-        m_PerforatedCell = std::make_shared<CPerforatedCell>(aMaterial, m_DescriptionCell);
+        m_PerforatedCell = std::make_shared<CPerforatedCell>(aMaterial, *m_DescriptionCell);
     }
 
 public:
@@ -50,7 +50,7 @@ TEST_F(TestCircularPerforatedCell, TestCircular1)
     SCOPED_TRACE("Begin Test: Circular perforated cell (Theta = 0, Phi = 0).");
 
     std::shared_ptr<CPerforatedCell> aCell = GetCell();
-    std::shared_ptr<ICellDescription> aCellDescription = GetDescription();
+    auto aCellDescription = GetDescription();
 
     double Theta = 0;   // deg
     double Phi = 0;     // deg
@@ -77,7 +77,7 @@ TEST_F(TestCircularPerforatedCell, TestCircular2)
     SCOPED_TRACE("Begin Test: Rectangular perforated cell (Theta = 45, Phi = 0).");
 
     std::shared_ptr<CPerforatedCell> aCell = GetCell();
-    std::shared_ptr<ICellDescription> aCellDescription = GetDescription();
+    auto aCellDescription = GetDescription();
 
     double Theta = 45;   // deg
     double Phi = 0;      // deg
@@ -104,7 +104,7 @@ TEST_F(TestCircularPerforatedCell, TestCircular3)
     SCOPED_TRACE("Begin Test: Rectangular perforated cell (Theta = 78, Phi = 45).");
 
     std::shared_ptr<CPerforatedCell> aCell = GetCell();
-    std::shared_ptr<ICellDescription> aCellDescription = GetDescription();
+    auto aCellDescription = GetDescription();
 
     double Theta = 78;   // deg
     double Phi = 45;     // deg

--- a/src/SingleLayerOptics/tst/units/DirectDiffuseCell1.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/DirectDiffuseCell1.unit.cpp
@@ -22,9 +22,8 @@ protected:
         constexpr auto Rbmat = 0.9;
         const auto aMaterial = Material::singleBandMaterial(Tfmat, Tbmat, Rfmat, Rbmat);
 
-        std::shared_ptr<ICellDescription> aCell = std::make_shared<CSpecularCellDescription>();
-
-        m_Cell = std::make_shared<CDirectionalDiffuseCell>(aMaterial, aCell);
+        m_Cell =
+          std::make_shared<CDirectionalDiffuseCell>(aMaterial, CSpecularCellDescription{});
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/PerfectDiffuseCell1.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/PerfectDiffuseCell1.unit.cpp
@@ -23,9 +23,7 @@ protected:
         const auto aMaterial = Material::singleBandMaterial(Tmat, Tmat, Rfmat, Rbmat);
 
         // make cell geometry
-        std::shared_ptr<ICellDescription> aCell = std::make_shared<CFlatCellDescription>();
-
-        m_Cell = std::make_shared<CUniformDiffuseCell>(aMaterial, aCell);
+        m_Cell = std::make_shared<CUniformDiffuseCell>(aMaterial, CFlatCellDescription{});
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/PerfectDiffuseCell2.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/PerfectDiffuseCell2.unit.cpp
@@ -23,9 +23,7 @@ protected:
         const auto aMaterial = Material::singleBandMaterial(Tmat, Tmat, Rfmat, Rbmat);
 
         // make cell geometry
-        std::shared_ptr<ICellDescription> aCell = std::make_shared<CFlatCellDescription>();
-
-        m_Cell = std::make_shared<CUniformDiffuseCell>(aMaterial, aCell);
+        m_Cell = std::make_shared<CUniformDiffuseCell>(aMaterial, CFlatCellDescription{});
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/RectangularPerforatedCell.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/RectangularPerforatedCell.unit.cpp
@@ -32,7 +32,7 @@ protected:
         m_DescriptionCell =
           std::make_shared<CRectangularCellDescription>(x, y, thickness, xHole, yHole);
 
-        m_PerforatedCell = std::make_shared<CPerforatedCell>(aMaterial, m_DescriptionCell);
+        m_PerforatedCell = std::make_shared<CPerforatedCell>(aMaterial, *m_DescriptionCell);
     }
 
 public:
@@ -52,7 +52,7 @@ TEST_F(TestRectangularPerforatedCell, TestRectangular1)
     SCOPED_TRACE("Begin Test: Rectangular perforated cell (Theta = 0, Phi = 0).");
 
     std::shared_ptr<CPerforatedCell> aCell = GetCell();
-    std::shared_ptr<ICellDescription> aCellDescription = GetDescription();
+    auto aCellDescription = GetDescription();
 
     const auto Theta = 0;   // deg
     const auto Phi = 0;     // deg
@@ -79,7 +79,7 @@ TEST_F(TestRectangularPerforatedCell, TestRectangular2)
     SCOPED_TRACE("Begin Test: Rectangular perforated cell (Theta = 45, Phi = 0).");
 
     std::shared_ptr<CPerforatedCell> aCell = GetCell();
-    std::shared_ptr<ICellDescription> aCellDescription = GetDescription();
+    auto aCellDescription = GetDescription();
 
     double Theta = 45;   // deg
     double Phi = 0;      // deg
@@ -106,7 +106,7 @@ TEST_F(TestRectangularPerforatedCell, TestRectangular3)
     SCOPED_TRACE("Begin Test: Rectangular perforated cell (Theta = 45, Phi = 45).");
 
     std::shared_ptr<CPerforatedCell> aCell = GetCell();
-    std::shared_ptr<ICellDescription> aCellDescription = GetDescription();
+    auto aCellDescription = GetDescription();
 
     const auto Theta = 45;   // deg
     const auto Phi = 45;     // deg

--- a/src/SingleLayerOptics/tst/units/VenetianCellCurved55_1.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/VenetianCellCurved55_1.unit.cpp
@@ -29,7 +29,7 @@ protected:
         const auto aCellDescription =
           std::make_shared<CVenetianCellDescription>(geometry, numOfSlatSegments);
 
-        m_Cell = std::make_shared<CVenetianCell>(aMaterial, aCellDescription);
+        m_Cell = std::make_shared<CVenetianCell>(aMaterial, *aCellDescription);
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/VenetianCellCurved55_2.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/VenetianCellCurved55_2.unit.cpp
@@ -34,7 +34,7 @@ protected:
         std::shared_ptr<CVenetianCellDescription> aCellDescription =
           std::make_shared<CVenetianCellDescription>(geometry, numOfSlatSegments);
 
-        m_Cell = std::make_shared<CVenetianCell>(aMaterial, aCellDescription);
+        m_Cell = std::make_shared<CVenetianCell>(aMaterial, *aCellDescription);
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/VenetianCellCurvedMinus55_1.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/VenetianCellCurvedMinus55_1.unit.cpp
@@ -34,7 +34,7 @@ protected:
         std::shared_ptr<CVenetianCellDescription> aCellDescription =
           std::make_shared<CVenetianCellDescription>(geometry, numOfSlatSegments);
 
-        m_Cell = std::make_shared<CVenetianCell>(aMaterial, aCellDescription);
+        m_Cell = std::make_shared<CVenetianCell>(aMaterial, *aCellDescription);
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/VenetianCellCurvedMinus55_2.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/VenetianCellCurvedMinus55_2.unit.cpp
@@ -34,7 +34,7 @@ protected:
         auto aCellDescription =
           std::make_shared<CVenetianCellDescription>(geometry, numOfSlatSegments);
 
-        m_Cell = std::make_shared<CVenetianCell>(aMaterial, aCellDescription);
+        m_Cell = std::make_shared<CVenetianCell>(aMaterial, *aCellDescription);
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/VenetianCellFlat0_1.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/VenetianCellFlat0_1.unit.cpp
@@ -34,7 +34,7 @@ protected:
         std::shared_ptr<CVenetianCellDescription> aCellDescription =
           std::make_shared<CVenetianCellDescription>(geometry, numOfSlatSegments);
 
-        m_Cell = std::make_shared<CVenetianCell>(aMaterial, aCellDescription);
+        m_Cell = std::make_shared<CVenetianCell>(aMaterial, *aCellDescription);
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/VenetianCellFlat0_2.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/VenetianCellFlat0_2.unit.cpp
@@ -35,7 +35,7 @@ protected:
         std::shared_ptr<CVenetianCellDescription> aCellDescription =
           std::make_shared<CVenetianCellDescription>(geometry, numOfSlatSegments);
 
-        m_Cell = std::make_shared<CVenetianCell>(aMaterial, aCellDescription);
+        m_Cell = std::make_shared<CVenetianCell>(aMaterial, *aCellDescription);
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/VenetianCellFlat0_3.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/VenetianCellFlat0_3.unit.cpp
@@ -11,7 +11,7 @@ using namespace FenestrationCommon;
 class TestVenetianCellFlat0_3 : public testing::Test
 {
 private:
-    CVenetianCell m_Cell{createMaterial(), createCellDescription()};
+    CVenetianCell m_Cell{createMaterial(), *createCellDescription()};
 
     static std::shared_ptr<CMaterial> createMaterial()
     {

--- a/src/SingleLayerOptics/tst/units/VenetianCellFlat0_4.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/VenetianCellFlat0_4.unit.cpp
@@ -9,7 +9,7 @@ using namespace FenestrationCommon;
 class TestVenetianCellFlat0_4 : public testing::Test
 {
 private:
-    CVenetianCell m_Cell{createMaterial(), createCellDescription()};
+    CVenetianCell m_Cell{createMaterial(), *createCellDescription()};
 
     static std::shared_ptr<CMaterial> createMaterial()
     {

--- a/src/SingleLayerOptics/tst/units/VenetianCellFlat45_1.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/VenetianCellFlat45_1.unit.cpp
@@ -35,7 +35,7 @@ protected:
         auto aCellDescription =
           std::make_shared<CVenetianCellDescription>(geometry, numOfSlatSegments);
 
-        m_Cell = std::make_shared<CVenetianCell>(aMaterial, aCellDescription);
+        m_Cell = std::make_shared<CVenetianCell>(aMaterial, *aCellDescription);
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/VenetianCellFlat45_2.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/VenetianCellFlat45_2.unit.cpp
@@ -35,7 +35,7 @@ protected:
         std::shared_ptr<CVenetianCellDescription> aCellDescription =
           std::make_shared<CVenetianCellDescription>(geometry, numOfSlatSegments);
 
-        m_Cell = std::make_shared<CVenetianCell>(aMaterial, aCellDescription);
+        m_Cell = std::make_shared<CVenetianCell>(aMaterial, *aCellDescription);
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/VenetianCellFlat45_3.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/VenetianCellFlat45_3.unit.cpp
@@ -35,7 +35,7 @@ protected:
         auto aCellDescription =
           std::make_shared<CVenetianCellDescription>(geometry, numOfSlatSegments);
 
-        m_Cell = std::make_shared<CVenetianCell>(aMaterial, aCellDescription);
+        m_Cell = std::make_shared<CVenetianCell>(aMaterial, *aCellDescription);
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/VenetianCellFlatMinus45_1.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/VenetianCellFlatMinus45_1.unit.cpp
@@ -35,7 +35,7 @@ protected:
         std::shared_ptr<CVenetianCellDescription> aCellDescription =
           std::make_shared<CVenetianCellDescription>(geometry, numOfSlatSegments);
 
-        m_Cell = std::make_shared<CVenetianCell>(aMaterial, aCellDescription);
+        m_Cell = std::make_shared<CVenetianCell>(aMaterial, *aCellDescription);
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/VenetianCellFlatMinus45_2.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/VenetianCellFlatMinus45_2.unit.cpp
@@ -34,7 +34,7 @@ protected:
         auto aCellDescription =
           std::make_shared<CVenetianCellDescription>(geometry, numOfSlatSegments);
 
-        m_Cell = std::make_shared<CVenetianCell>(aMaterial, aCellDescription);
+        m_Cell = std::make_shared<CVenetianCell>(aMaterial, *aCellDescription);
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/WovenCell1.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/WovenCell1.unit.cpp
@@ -25,10 +25,7 @@ protected:
         // make cell geometry
         const auto diameter = 6.35;   // mm
         const auto spacing = 19.05;   // mm
-        std::shared_ptr<ICellDescription> aCell =
-          std::make_shared<CWovenCellDescription>(diameter, spacing);
-
-        m_Cell = std::make_shared<CWovenCell>(aMaterial, aCell);
+        m_Cell = std::make_shared<CWovenCell>(aMaterial, CWovenCellDescription{diameter, spacing});
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/WovenCell2.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/WovenCell2.unit.cpp
@@ -25,10 +25,7 @@ protected:
         // make cell geometry
         const auto diameter = 6.35;   // mm
         const auto spacing = 19.05;   // mm
-        std::shared_ptr<ICellDescription> aCell =
-          std::make_shared<CWovenCellDescription>(diameter, spacing);
-
-        m_Cell = std::make_shared<CWovenCell>(aMaterial, aCell);
+        m_Cell = std::make_shared<CWovenCell>(aMaterial, CWovenCellDescription{diameter, spacing});
     }
 
 public:

--- a/src/SingleLayerOptics/tst/units/WovenCell3.unit.cpp
+++ b/src/SingleLayerOptics/tst/units/WovenCell3.unit.cpp
@@ -25,10 +25,7 @@ protected:
         // make cell geometry
         const auto diameter = 6.35;   // mm
         const auto spacing = 19.05;   // mm
-        std::shared_ptr<ICellDescription> aCell =
-          std::make_shared<CWovenCellDescription>(diameter, spacing);
-
-        m_Cell = std::make_shared<CWovenCell>(aMaterial, aCell);
+        m_Cell = std::make_shared<CWovenCell>(aMaterial, CWovenCellDescription{diameter, spacing});
     }
 
 public:


### PR DESCRIPTION
## Summary

Converts the SingleLayerOptics cell-description hierarchy from a polymorphic `ICellDescription` base (held via `shared_ptr`) to a `std::variant` of plain value types (`CellDescription`) with a free-function `Beam_dir_dir` dispatch. First pilot in a larger effort to move the optics modules to value semantics (remove inheritance + `shared_ptr`).

- Drop `ICellDescription`; the six concrete descriptions become value types (perforated base flattened into circular/rectangular).
- `CBaseCell` and every cell constructor store/take `CellDescription` by value; `getCellAs*` return references into the variant instead of `dynamic_pointer_cast`.
- Venetian energy machinery shares a `VenetianGeometry` bundle (`cell`, `viewFactors`, `mesh`) per forward/backward description; new `VenetianSegmentsTypes.hpp` breaks the former `VenetianSegments` / `VenetianCellDescription` include cycle.
- `CBSDFLayerMaker` / `CScatteringLayer` constructors take `std::optional<CellDescription>`.

## API stability

Public surface is unchanged (`CBSDFLayerMaker` factories, `CBSDFLayer` / `IScatteringLayer` / `CMaterial` keep their signatures). WinCalc builds against this branch with zero changes (verified via the `local-release` preset pointing FetchContent at a local working copy).

## Verification

- WCE builds clean (both optics modules).
- All 1072 unit tests pass.
- WinCalc + its test target compile/link against this branch unchanged.

## Performance follow-up — fixed

Benchmarked vs `main`: full suite 24.8s vs 28.3s, Venetian subset (153 tests) ~0.62s vs ~0.60s — within noise.

- [x] Fix Venetian view-factor recomputation. The value-copy conversion made every `m_EnergiesBand[i]` redo `CGeometry2D`'s enclosure view factors and rebuild the slat mesh. Introduced a `VenetianGeometry` bundle (`cell`, `viewFactors`, `mesh`) built once per forward/backward description and shared across the band via `shared_ptr`. The description itself stays a value type; only the derived geometry-only results are shared. Per-wavelength state (`LayerProperties`, `slatsDiffuseRadiancesMatrix`, direction caches) stays per-cell. Isolated to `VenetianSegments.{hpp,cpp}` / `VenetianCell.{hpp,cpp}`.

## Later phases (separate PRs)

- `CBaseCell` subclass tree incl. the `CVenetianBase` virtual diamond.
- `CBSDFLayer` subclass tree → single class + variant diffuse-distribution strategy.
- Coordinated WinCalc change to de-inherit `CMaterial` / `IScatteringLayer` and drop `shared_ptr` at the public boundary.
